### PR TITLE
Updating IRIS Alerter to use ElastAlert Alerter defaults

### DIFF
--- a/elastalert/alerters/iris.py
+++ b/elastalert/alerters/iris.py
@@ -75,8 +75,12 @@ class IrisAlerter(Alerter):
         else:
             event_timestamp = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
 
+        # If no description is supplied use the built-in alert body generator which accounts for alert_text and alert_text_args
+        if not self.description:
+            self.description = self.create_alert_body(matches)
+        
         alert_data = {
-            "alert_title": self.rule.get('name'),
+            "alert_title": self.create_title(matches),
             "alert_description": self.description,
             "alert_source": "ElastAlert2",
             "alert_severity_id": self.alert_severity_id,


### PR DESCRIPTION
## Description

Currently the IRIS alert uses rule supplied values for the description and simply uses the rule title for the alert title. This significantly reduces the ability to dynamically create/repurpose alerts as the rule creator must tailor each individual alert with a custom description. Additionally this description field as it stands does not resolve any variable or template fields resulting in a static description for all alerts.

This PR aims to resolve this by using the built in create_alert_body() and create_title() functions within the Alerter class. 

As this is possibly a breaking change I'm opening this PR as a draft for discussion.

## Checklist

<!--
The following checklist items must be completed before PRs can be merged. 
-->

- [ ] I have reviewed the [contributing guidelines](https://github.com/jertel/elastalert2/blob/master/CONTRIBUTING.md).
- [ ] I have included unit tests for my changes or additions.
- [ ] I have successfully run `make test-docker` with my changes.
- [ ] I have manually tested all relevant modes of the change in this PR.
- [ ] I have updated the [documentation](https://elastalert2.readthedocs.io).
- [ ] I have updated the [changelog](https://github.com/jertel/elastalert2/blob/master/CHANGELOG.md).


## Questions or Comments

<!--
If any of the checklist items do not apply, note the reasoning for each. If you're simply
upgrading a library version, you do not need to explain why the docs or unit tests checklist
items are not checked, however the changelog should be updated to reflect the new version.

If you have questions about completing this PR, or about the process, note them here.

If you are not ready for this PR to be reviewed please mention that here.
-->

Do not merge this PR until discussed! :)